### PR TITLE
add feature swop urls for #1

### DIFF
--- a/source/injected/twisome.js
+++ b/source/injected/twisome.js
@@ -202,6 +202,8 @@ function createNewUndoNode() {
 
 // Callback function to execute when mutations are observed
 function mutationObserverForTweetButton(mutationsList, observer) {
+  // swop urls if content added
+  swopUrls()
   setTimeout(function () {
     const undoButton = document.getElementById(UNDO_BUTTON_SELECTOR_ID)
     let tweetButton = document.querySelectorAll(TWITTER_BUTTON_SELECTOR)[0]
@@ -213,6 +215,23 @@ function mutationObserverForTweetButton(mutationsList, observer) {
   }, DELAY_TIME_ATTACH_UNDO_BUTTON)
 }
 
+// Swop the title from twitter t.co to the url
+function swopUrls() {
+  // skip title boxes (they do not provide a title)
+  document.querySelectorAll('A[href*="https://t.co/"]').forEach((el) => {
+    if (el.title) {
+      // swopped href to title
+      el.href = el.title
+    } else if ((el.role = 'link')) {
+      //  `no title for ${el.href}`
+      // unfurlr?
+    }
+  })
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  swopUrls()
+})
 // Create an observer instance linked to the callback function
 // Select the node that will be observed for mutations
 const bodyNode = document.querySelector('body')


### PR DESCRIPTION
urls that have a title defined can swop the href of t.co to the actual url not the shortened version

 enabling this feature should be behind the options popup

it does not currently check to see if it is a valid url 
This can be added by one or both of below

- url check
```
try { 
  let url=new URL(el.title);
  el.href=url
 } catch (err) {
// do not swop
 }
```
- or some superlative url regexp

There maybe a better way to change the url so that it doesn't recheck or retry the url swops that have failed?
Push to a map?
